### PR TITLE
Replace 'master' references with 'main' across configuration files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: write

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,7 @@ html_theme_options = {
         "edit",
     ],
     "source_repository": "https://github.com/saurabheights/Pixion",
-    "source_branch": "master",
+    "source_branch": "main",
     "source_directory": "docs/source/",
 }
 

--- a/docs/source/development/license.rst
+++ b/docs/source/development/license.rst
@@ -14,4 +14,4 @@ distributed modifications remain free and open source.
   - Provide source code
   - Use the same GPLv3 license
 
-The full license text is available in the repository: `LICENSE <https://github.com/saurabheights/Pixion/blob/master/LICENSE>`_
+The full license text is available in the repository: `LICENSE <https://github.com/saurabheights/Pixion/blob/main/LICENSE>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ docstring-code-format = false
 docstring-code-line-length = "dynamic"
 
 [tool.semantic_release]
-branch = "master"
+branch = "main"
 version_source = "file"
 version_variable = "pyproject.toml:project.version"
 version_toml = [


### PR DESCRIPTION
Updated pyproject.toml, conf.py, license.rst, and release.yml to reflect the new primary branch name.